### PR TITLE
Add cache folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ graphml_files
 *_frames/
 *.html
 *.txt
+__pycache__
+cache
+frames


### PR DESCRIPTION
This PR will add particular cache folders that are created when importing python modules as a package to the .gitignore file. 